### PR TITLE
Use delegate name in 'support delegated to...' info.

### DIFF
--- a/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -1,5 +1,5 @@
 <% if session[:delegated_to] %>
-  Support delegated to <%= session[:delegated_to] %>
+  Support delegated to <%= Decidim::User.find_by(email: session[:delegated_to]).name %>
   <form action="/liquidvoting/delegations" method="POST">
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
     <input type="hidden" name="delegator_email" value="<%= current_user.email %>">


### PR DESCRIPTION
Addresses some of #9

Pull name from Decidim db using `find_by(email: ...)` and insert into displayed info. text.

![delegate_name](https://user-images.githubusercontent.com/3944042/97592304-66ab0580-19f8-11eb-8920-3e671858843a.png)
